### PR TITLE
need to use pkg_check_modules to get libuvc libraries in Ubuntu 24.04/Debian Trixie

### DIFF
--- a/libuvc_camera/CMakeLists.txt
+++ b/libuvc_camera/CMakeLists.txt
@@ -9,6 +9,11 @@ generate_dynamic_reconfigure_options(cfg/UVCCamera.cfg)
 find_package(libuvc REQUIRED)
 message(STATUS "libuvc ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH}")
 
+# this is needed to get the libuvc libraries in libuvc 0.0.7
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libuvc REQUIRED libuvc)
+message(STATUS "libuvc libraries ${libuvc_LIBRARIES}")
+
 catkin_package(
   CATKIN_DEPENDS
     roscpp


### PR DESCRIPTION
`libuvc_LIBRARIES` isn't set by find_package(libuvc) in libuvc 0.0.7 (https://packages.ubuntu.com/noble/libuvc-dev https://packages.debian.org/trixie/libuvc-dev), but adding this pkg_check_module makes it work- maybe there is a better way, and support 0.0.6 and 0.0.7?

Some discussion that led me to this solution:
https://github.com/libuvc/libuvc/pull/125#issuecomment-768650154

I've only tested this in a Ubuntu 24.04 docker container and outside in Ubuntu 23.10, maybe it's premature to merge it in.